### PR TITLE
change markdown image to figure shortcode

### DIFF
--- a/content/challenges/SOC-engineer.md
+++ b/content/challenges/SOC-engineer.md
@@ -29,8 +29,7 @@ The following challenges should take no longer than 30 - 45 minutes. Complete th
 
 #### NOTE: Issues can NOT be remediated in hours
 
-![Scenario](https://pbx-group-security.com/img/SOCScenario.png)
-
+{{< figure src="/img/SOCScenario.png" title="" width="847px" >}}
 
 
 ### Practical Exercise


### PR DESCRIPTION
This is for issue #70.

The size is the  max width of the container, without the search box and tags, so it seems small...